### PR TITLE
Remove IP adress if machine didn't exist

### DIFF
--- a/driver/scaleway.go
+++ b/driver/scaleway.go
@@ -347,10 +347,7 @@ func (d *Driver) Remove() (err error) {
 	if err != nil {
 		return
 	}
-	err = cl.PostServerAction(d.ServerID, "terminate")
-	if err != nil {
-		return
-	}
+	errRemove := cl.PostServerAction(d.ServerID, "terminate")
 	for {
 		_, err = cl.GetServer(d.ServerID)
 		if err != nil {
@@ -359,6 +356,9 @@ func (d *Driver) Remove() (err error) {
 	}
 	if !d.IPPersistant {
 		err = cl.DeleteIP(d.IPID)
+	}
+	if errRemove != nil {
+		return
 	}
 	return
 }

--- a/driver/scaleway.go
+++ b/driver/scaleway.go
@@ -358,6 +358,7 @@ func (d *Driver) Remove() (err error) {
 		err = cl.DeleteIP(d.IPID)
 	}
 	if errRemove != nil {
+		err = errRemove
 		return
 	}
 	return


### PR DESCRIPTION
Hi, while I try to fix #63 I found some bug: if docker-machine fail create instance it still create ip address.  And that address not deleted with `docker-machine rm`. 