### PR TITLE
Allow the bootscript to be specified using it's unique id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Options:
    --scaleway-commercial-type "VC1S"                                                                 Specifies the commercial type [$SCALEWAY_COMMERCIAL_TYPE]
    --scaleway-debug                                                                                  Enables Scaleway client debugging [$SCALEWAY_DEBUG]
    --scaleway-image "ubuntu-xenial"                                                                  Specifies the image [$SCALEWAY_IMAGE]
+   --scaleway-bootscript "docker"                                                                    Specifies the bootscript [$SCALEWAY_BOOTSCRIPT]
    --scaleway-ip                                                                                     Specifies the IP address [$SCALEWAY_IP]
    --scaleway-ipv6                                                                                   Enable ipv6 [$SCALEWAY_IPV6]
    --scaleway-name                                                                                   Assign a name [$SCALEWAY_NAME]

--- a/driver/scaleway.go
+++ b/driver/scaleway.go
@@ -41,6 +41,7 @@ type Driver struct {
 	Region         string
 	name           string
 	image          string
+	bootscript     string
 	ip             string
 	volumes        string
 	IPPersistant   bool
@@ -94,6 +95,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) (err error) {
 	d.Region = flags.String("scaleway-region")
 	d.name = flags.String("scaleway-name")
 	d.image = flags.String("scaleway-image")
+	d.bootscript = flags.String("scaleway-bootscript")
 	d.ip = flags.String("scaleway-ip")
 	d.volumes = flags.String("scaleway-volumes")
 	d.ipv6 = flags.Bool("scaleway-ipv6")
@@ -144,6 +146,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "scaleway-image",
 			Usage:  "Specifies the image",
 			Value:  defaultImage,
+		},
+		mcnflag.StringFlag{
+			EnvVar: "SCALEWAY_BOOTSCRIPT",
+			Name:   "scaleway-bootscript",
+			Usage:  "Specifies the bootscript",
+			Value:  defaultBootscript,
 		},
 		mcnflag.StringFlag{
 			EnvVar: "SCALEWAY_IP",
@@ -259,7 +267,7 @@ func (d *Driver) Create() (err error) {
 		ImageName:         d.image,
 		CommercialType:    d.CommercialType,
 		Name:              d.name,
-		Bootscript:        defaultBootscript,
+		Bootscript:        d.bootscript,
 		AdditionalVolumes: d.volumes,
 		IP:                d.IPID,
 		EnableIPV6:        d.ipv6,


### PR DESCRIPTION
Related to some of the issues we are seeing in: https://github.com/scaleway/docker-machine-driver-scaleway/issues/84

Right now the 'docker' bootscript, is still the default, though that does not appear to exist in scaleway anymore. I've left it as the default until we hear for sure it's not coming back. 

With this PR, you can pass the name of a bootscript to use it, and you can also pass `--scaleway-bootscript=""` to clear the default, and let the scaleway server use it's default. (The default kernels are supposed to work with docker and docker-machine now)

I have tested that using this with 'docker' image is working.

A separate issue right now is that the default image, 'ubuntu-xenial', also doesn't exist, so you need to manually specify an image. 